### PR TITLE
Https245

### DIFF
--- a/src/FrameworkContainers/FrameworkContainers.csproj
+++ b/src/FrameworkContainers/FrameworkContainers.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ContainerExpressions" Version="9.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="ContainerExpressions" Version="10.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.3" />
   </ItemGroup>
 
 	<PropertyGroup>

--- a/src/FrameworkContainers/Network/HttpCollective/Http.cs
+++ b/src/FrameworkContainers/Network/HttpCollective/Http.cs
@@ -204,15 +204,15 @@ public static class Http
             .Match(Parse<TResponse>(options), Identity<TResponse>);
     }
 
-    public static Http245 Get245(string body, Either<string, Uri> url, string contentType, params Header[] headers)
+    public static Http245 Get245(Either<string, Uri> url, params Header[] headers)
     {
-        return Get245(body, url, contentType, HttpOptions.Default, headers);
+        return Get245(url, HttpOptions.Default, headers);
     }
 
-    public static Http245 Get245(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers)
+    public static Http245 Get245(Either<string, Uri> url, HttpOptions options, params Header[] headers)
     {
         return HypertextTransferProtocol
-            .Send245(body, url.Match(static x => new Uri(x), Identity), contentType, options, headers, Constants.Http.GET)
+            .Send245(string.Empty, url.Match(static x => new Uri(x), Identity), string.Empty, options, headers, Constants.Http.GET)
             .Match(Identity, Identity<Http245>);
     }
 

--- a/src/FrameworkContainers/Network/HttpCollective/Http.cs
+++ b/src/FrameworkContainers/Network/HttpCollective/Http.cs
@@ -264,6 +264,18 @@ public static class Http
             .Match(HttpStatus.Create, Identity<HttpStatus>);
     }
 
+    public static Task<Http245> Post245Async(string body, Either<string, Uri> url, string contentType, params Header[] headers)
+    {
+        return Post245Async(body, url, contentType, HttpOptions.Default, headers);
+    }
+
+    public static Task<Http245> Post245Async(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers)
+    {
+        return HypertextTransferProtocol
+            .Send245Async(body, url.Match(static x => new Uri(x), Identity), contentType, options, headers, HttpMethod.Post)
+            .ContinueWith(IdentityValue);
+    }
+
     public static Task<HttpBody> PostAsync(string body, Either<string, Uri> url, string contentType, params Header[] headers)
     {
         return PostAsync(body, url, contentType, HttpOptions.Default, headers);
@@ -309,6 +321,18 @@ public static class Http
     {
         return HypertextTransferProtocol
             .SendJsonAsync<TRequest, TResponse>(model, url.Match(static x => new Uri(x), Identity), options, headers, HttpMethod.Post)
+            .ContinueWith(IdentityValue);
+    }
+
+    public static Task<Http245> Put245Async(string body, Either<string, Uri> url, string contentType, params Header[] headers)
+    {
+        return Put245Async(body, url, contentType, HttpOptions.Default, headers);
+    }
+
+    public static Task<Http245> Put245Async(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers)
+    {
+        return HypertextTransferProtocol
+            .Send245Async(body, url.Match(static x => new Uri(x), Identity), contentType, options, headers, HttpMethod.Put)
             .ContinueWith(IdentityValue);
     }
 
@@ -360,6 +384,18 @@ public static class Http
             .ContinueWith(IdentityValue);
     }
 
+    public static Task<Http245> Patch245Async(string body, Either<string, Uri> url, string contentType, params Header[] headers)
+    {
+        return Patch245Async(body, url, contentType, HttpOptions.Default, headers);
+    }
+
+    public static Task<Http245> Patch245Async(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers)
+    {
+        return HypertextTransferProtocol
+            .Send245Async(body, url.Match(static x => new Uri(x), Identity), contentType, options, headers, HypertextTransferProtocol.Patch)
+            .ContinueWith(IdentityValue);
+    }
+
     public static Task<HttpBody> PatchAsync(string body, Either<string, Uri> url, string contentType, params Header[] headers)
     {
         return PatchAsync(body, url, contentType, HttpOptions.Default, headers);
@@ -405,6 +441,18 @@ public static class Http
     {
         return HypertextTransferProtocol
             .SendJsonAsync<TRequest, TResponse>(model, url.Match(static x => new Uri(x), Identity), options, headers, HypertextTransferProtocol.Patch)
+            .ContinueWith(IdentityValue);
+    }
+
+    public static Task<Http245> Get245Async(Either<string, Uri> url, params Header[] headers)
+    {
+        return Get245Async(url, HttpOptions.Default, headers);
+    }
+
+    public static Task<Http245> Get245Async(Either<string, Uri> url, HttpOptions options, params Header[] headers)
+    {
+        return HypertextTransferProtocol
+            .Send245Async(string.Empty, url.Match(static x => new Uri(x), Identity), string.Empty, options, headers, HttpMethod.Get)
             .ContinueWith(IdentityValue);
     }
 

--- a/src/FrameworkContainers/Network/HttpCollective/Http.cs
+++ b/src/FrameworkContainers/Network/HttpCollective/Http.cs
@@ -24,6 +24,18 @@ public static class Http
 
     private static Func<string, T> Parse<T>(JsonOptions options) { return json => Json.ToModel<T>(json, options); }
 
+    public static Http245 Post245(string body, Either<string, Uri> url, string contentType, params Header[] headers)
+    {
+        return Post245(body, url, contentType, HttpOptions.Default, headers);
+    }
+
+    public static Http245 Post245(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers)
+    {
+        return HypertextTransferProtocol
+            .Send245(body, url.Match(static x => new Uri(x), Identity), contentType, options, headers, Constants.Http.POST)
+            .Match(Identity, Identity<Http245>);
+    }
+
     public static HttpBody Post(string body, Either<string, Uri> url, string contentType, params Header[] headers)
     {
         return Post(body, url, contentType, HttpOptions.Default, headers);

--- a/src/FrameworkContainers/Network/HttpCollective/Http.cs
+++ b/src/FrameworkContainers/Network/HttpCollective/Http.cs
@@ -84,6 +84,18 @@ public static class Http
             .Match(Parse<TResponse>(options), Identity<TResponse>);
     }
 
+    public static Http245 Put245(string body, Either<string, Uri> url, string contentType, params Header[] headers)
+    {
+        return Put245(body, url, contentType, HttpOptions.Default, headers);
+    }
+
+    public static Http245 Put245(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers)
+    {
+        return HypertextTransferProtocol
+            .Send245(body, url.Match(static x => new Uri(x), Identity), contentType, options, headers, Constants.Http.PUT)
+            .Match(Identity, Identity<Http245>);
+    }
+
     public static HttpBody Put(string body, Either<string, Uri> url, string contentType, params Header[] headers)
     {
         return Put(body, url, contentType, HttpOptions.Default, headers);
@@ -132,6 +144,18 @@ public static class Http
             .Match(Parse<TResponse>(options), Identity<TResponse>);
     }
 
+    public static Http245 Patch245(string body, Either<string, Uri> url, string contentType, params Header[] headers)
+    {
+        return Patch245(body, url, contentType, HttpOptions.Default, headers);
+    }
+
+    public static Http245 Patch245(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers)
+    {
+        return HypertextTransferProtocol
+            .Send245(body, url.Match(static x => new Uri(x), Identity), contentType, options, headers, Constants.Http.PATCH)
+            .Match(Identity, Identity<Http245>);
+    }
+
     public static HttpBody Patch(string body, Either<string, Uri> url, string contentType, params Header[] headers)
     {
         return Patch(body, url, contentType, HttpOptions.Default, headers);
@@ -178,6 +202,18 @@ public static class Http
         return HypertextTransferProtocol
             .Send(Json.FromModel(model, options), url.Match(static x => new Uri(x), Identity), Constants.Http.JSON_CONTENT, options, headers, Constants.Http.PATCH)
             .Match(Parse<TResponse>(options), Identity<TResponse>);
+    }
+
+    public static Http245 Get245(string body, Either<string, Uri> url, string contentType, params Header[] headers)
+    {
+        return Get245(body, url, contentType, HttpOptions.Default, headers);
+    }
+
+    public static Http245 Get245(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers)
+    {
+        return HypertextTransferProtocol
+            .Send245(body, url.Match(static x => new Uri(x), Identity), contentType, options, headers, Constants.Http.GET)
+            .Match(Identity, Identity<Http245>);
     }
 
     public static HttpBody Get(Either<string, Uri> url, params Header[] headers)

--- a/src/FrameworkContainers/Network/HttpCollective/HttpClient.cs
+++ b/src/FrameworkContainers/Network/HttpCollective/HttpClient.cs
@@ -22,6 +22,8 @@ public interface IHttpClient
     TResponse PostJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, params Header[] headers);
     TResponse PostJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, HttpOptions options, params Header[] headers);
 
+    Http245 Put245(string body, Either<string, Uri> url, string contentType, params Header[] headers);
+    Http245 Put245(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers);
     HttpBody Put(string body, Either<string, Uri> url, string contentType, params Header[] headers);
     HttpBody Put(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers);
     HttpStatus PutStatus(string body, Either<string, Uri> url, string contentType, params Header[] headers);
@@ -31,6 +33,8 @@ public interface IHttpClient
     TResponse PutJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, params Header[] headers);
     TResponse PutJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, HttpOptions options, params Header[] headers);
 
+    Http245 Patch245(string body, Either<string, Uri> url, string contentType, params Header[] headers);
+    Http245 Patch245(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers);
     HttpBody Patch(string body, Either<string, Uri> url, string contentType, params Header[] headers);
     HttpBody Patch(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers);
     HttpStatus PatchStatus(string body, Either<string, Uri> url, string contentType, params Header[] headers);
@@ -40,6 +44,8 @@ public interface IHttpClient
     TResponse PatchJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, params Header[] headers);
     TResponse PatchJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, HttpOptions options, params Header[] headers);
 
+    Http245 Get245(string body, Either<string, Uri> url, string contentType, params Header[] headers);
+    Http245 Get245(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers);
     HttpBody Get(Either<string, Uri> url, params Header[] headers);
     HttpBody Get(Either<string, Uri> url, HttpOptions options, params Header[] headers);
     HttpStatus GetStatus(Either<string, Uri> url, params Header[] headers);
@@ -104,6 +110,8 @@ public sealed class HttpClient : IHttpClient
     public TResponse PostJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, params Header[] headers) => Http.PostJson<TRequest, TResponse>(model, url, headers);
     public TResponse PostJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, HttpOptions options, params Header[] headers) => Http.PostJson<TRequest, TResponse>(model, url, options, headers);
 
+    public Http245 Put245(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.Put245(body, url, contentType, headers);
+    public Http245 Put245(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers) => Http.Put245(body, url, contentType, options, headers);
     public HttpBody Put(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.Put(body, url, contentType, headers);
     public HttpBody Put(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers) => Http.Put(body, url, contentType, options, headers);
     public HttpStatus PutStatus(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.PutStatus(body, url, contentType, headers);
@@ -113,6 +121,8 @@ public sealed class HttpClient : IHttpClient
     public TResponse PutJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, params Header[] headers) => Http.PutJson<TRequest, TResponse>(model, url, headers);
     public TResponse PutJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, HttpOptions options, params Header[] headers) => Http.PutJson<TRequest, TResponse>(model, url, options, headers);
 
+    public Http245 Patch245(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.Patch245(body, url, contentType, headers);
+    public Http245 Patch245(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers) => Http.Patch245(body, url, contentType, options, headers);
     public HttpBody Patch(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.Patch(body, url, contentType, headers);
     public HttpBody Patch(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers) => Http.Patch(body, url, contentType, options, headers);
     public HttpStatus PatchStatus(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.PatchStatus(body, url, contentType, headers);
@@ -122,6 +132,8 @@ public sealed class HttpClient : IHttpClient
     public TResponse PatchJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, params Header[] headers) => Http.PatchJson<TRequest, TResponse>(model, url, headers);
     public TResponse PatchJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, HttpOptions options, params Header[] headers) => Http.PatchJson<TRequest, TResponse>(model, url, options, headers);
 
+    public Http245 Get245(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.Get245(body, url, contentType, headers);
+    public Http245 Get245(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers) => Http.Get245(body, url, contentType, options, headers);
     public HttpBody Get(Either<string, Uri> url, params Header[] headers) => Http.Get(url, headers);
     public HttpBody Get(Either<string, Uri> url, HttpOptions options, params Header[] headers) => Http.Get(url, options, headers);
     public HttpStatus GetStatus(Either<string, Uri> url, params Header[] headers) => Http.GetStatus(url, headers);

--- a/src/FrameworkContainers/Network/HttpCollective/HttpClient.cs
+++ b/src/FrameworkContainers/Network/HttpCollective/HttpClient.cs
@@ -56,6 +56,8 @@ public interface IHttpClient
     HttpStatus DeleteStatus(Either<string, Uri> url, params Header[] headers);
     HttpStatus DeleteStatus(Either<string, Uri> url, HttpOptions options, params Header[] headers);
 
+    Task<Http245> Post245Async(string body, Either<string, Uri> url, string contentType, params Header[] headers);
+    Task<Http245> Post245Async(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers);
     Task<HttpBody> PostAsync(string body, Either<string, Uri> url, string contentType, params Header[] headers);
     Task<HttpBody> PostAsync(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers);
     Task<HttpStatus> PostStatusAsync(string body, Either<string, Uri> url, string contentType, params Header[] headers);
@@ -65,6 +67,8 @@ public interface IHttpClient
     Task<TResponse> PostJsonAsync<TRequest, TResponse>(TRequest model, Either<string, Uri> url, params Header[] headers);
     Task<TResponse> PostJsonAsync<TRequest, TResponse>(TRequest model, Either<string, Uri> url, HttpOptions options, params Header[] headers);
 
+    Task<Http245> Put245Async(string body, Either<string, Uri> url, string contentType, params Header[] headers);
+    Task<Http245> Put245Async(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers);
     Task<HttpBody> PutAsync(string body, Either<string, Uri> url, string contentType, params Header[] headers);
     Task<HttpBody> PutAsync(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers);
     Task<HttpStatus> PutStatusAsync(string body, Either<string, Uri> url, string contentType, params Header[] headers);
@@ -74,6 +78,8 @@ public interface IHttpClient
     Task<TResponse> PutJsonAsync<TRequest, TResponse>(TRequest model, Either<string, Uri> url, params Header[] headers);
     Task<TResponse> PutJsonAsync<TRequest, TResponse>(TRequest model, Either<string, Uri> url, HttpOptions options, params Header[] headers);
 
+    Task<Http245> Patch245Async(string body, Either<string, Uri> url, string contentType, params Header[] headers);
+    Task<Http245> Patch245Async(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers);
     Task<HttpBody> PatchAsync(string body, Either<string, Uri> url, string contentType, params Header[] headers);
     Task<HttpBody> PatchAsync(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers);
     Task<HttpStatus> PatchStatusAsync(string body, Either<string, Uri> url, string contentType, params Header[] headers);
@@ -83,6 +89,8 @@ public interface IHttpClient
     Task<TResponse> PatchJsonAsync<TRequest, TResponse>(TRequest model, Either<string, Uri> url, params Header[] headers);
     Task<TResponse> PatchJsonAsync<TRequest, TResponse>(TRequest model, Either<string, Uri> url, HttpOptions options, params Header[] headers);
 
+    Task<Http245> Get245Async(Either<string, Uri> url, params Header[] headers);
+    Task<Http245> Get245Async(Either<string, Uri> url, HttpOptions options, params Header[] headers);
     Task<HttpBody> GetAsync(Either<string, Uri> url, params Header[] headers);
     Task<HttpBody> GetAsync(Either<string, Uri> url, HttpOptions options, params Header[] headers);
     Task<HttpStatus> GetStatusAsync(Either<string, Uri> url, params Header[] headers);
@@ -144,6 +152,8 @@ public sealed class HttpClient : IHttpClient
     public HttpStatus DeleteStatus(Either<string, Uri> url, params Header[] headers) => Http.DeleteStatus(url, headers);
     public HttpStatus DeleteStatus(Either<string, Uri> url, HttpOptions options, params Header[] headers) => Http.DeleteStatus(url, options, headers);
 
+    public Task<Http245> Post245Async(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.Post245Async(body, url, contentType, headers);
+    public Task<Http245> Post245Async(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers) => Http.Post245Async(body, url, contentType, options, headers);
     public Task<HttpBody> PostAsync(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.PostAsync(body, url, contentType, headers);
     public Task<HttpBody> PostAsync(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers) => Http.PostAsync(body, url, contentType, options, headers);
     public Task<HttpStatus> PostStatusAsync(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.PostStatusAsync(body, url, contentType, headers);
@@ -153,6 +163,8 @@ public sealed class HttpClient : IHttpClient
     public Task<TResponse> PostJsonAsync<TRequest, TResponse>(TRequest model, Either<string, Uri> url, params Header[] headers) => Http.PostJsonAsync<TRequest, TResponse>(model, url, headers);
     public Task<TResponse> PostJsonAsync<TRequest, TResponse>(TRequest model, Either<string, Uri> url, HttpOptions options, params Header[] headers) => Http.PostJsonAsync<TRequest, TResponse>(model, url, options, headers);
 
+    public Task<Http245> Put245Async(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.Put245Async(body, url, contentType, headers);
+    public Task<Http245> Put245Async(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers) => Http.Put245Async(body, url, contentType, options, headers);
     public Task<HttpBody> PutAsync(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.PutAsync(body, url, contentType, headers);
     public Task<HttpBody> PutAsync(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers) => Http.PutAsync(body, url, contentType, options, headers);
     public Task<HttpStatus> PutStatusAsync(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.PutStatusAsync(body, url, contentType, headers);
@@ -162,6 +174,8 @@ public sealed class HttpClient : IHttpClient
     public Task<TResponse> PutJsonAsync<TRequest, TResponse>(TRequest model, Either<string, Uri> url, params Header[] headers) => Http.PutJsonAsync<TRequest, TResponse>(model, url, headers);
     public Task<TResponse> PutJsonAsync<TRequest, TResponse>(TRequest model, Either<string, Uri> url, HttpOptions options, params Header[] headers) => Http.PutJsonAsync<TRequest, TResponse>(model, url, options, headers);
 
+    public Task<Http245> Patch245Async(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.Patch245Async(body, url, contentType, headers);
+    public Task<Http245> Patch245Async(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers) => Http.Patch245Async(body, url, contentType, options, headers);
     public Task<HttpBody> PatchAsync(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.PatchAsync(body, url, contentType, headers);
     public Task<HttpBody> PatchAsync(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers) => Http.PatchAsync(body, url, contentType, options, headers);
     public Task<HttpStatus> PatchStatusAsync(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.PatchStatusAsync(body, url, contentType, headers);
@@ -171,6 +185,8 @@ public sealed class HttpClient : IHttpClient
     public Task<TResponse> PatchJsonAsync<TRequest, TResponse>(TRequest model, Either<string, Uri> url, params Header[] headers) => Http.PatchJsonAsync<TRequest, TResponse>(model, url, headers);
     public Task<TResponse> PatchJsonAsync<TRequest, TResponse>(TRequest model, Either<string, Uri> url, HttpOptions options, params Header[] headers) => Http.PatchJsonAsync<TRequest, TResponse>(model, url, options, headers);
 
+    public Task<Http245> Get245Async(Either<string, Uri> url, params Header[] headers) => Http.Get245Async(url, headers);
+    public Task<Http245> Get245Async(Either<string, Uri> url, HttpOptions options, params Header[] headers) => Http.Get245Async(url, options, headers);
     public Task<HttpBody> GetAsync(Either<string, Uri> url, params Header[] headers) => Http.GetAsync(url, headers);
     public Task<HttpBody> GetAsync(Either<string, Uri> url, HttpOptions options, params Header[] headers) => Http.GetAsync(url, options, headers);
     public Task<HttpStatus> GetStatusAsync(Either<string, Uri> url, params Header[] headers) => Http.GetStatusAsync(url, headers);

--- a/src/FrameworkContainers/Network/HttpCollective/HttpClient.cs
+++ b/src/FrameworkContainers/Network/HttpCollective/HttpClient.cs
@@ -44,8 +44,8 @@ public interface IHttpClient
     TResponse PatchJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, params Header[] headers);
     TResponse PatchJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, HttpOptions options, params Header[] headers);
 
-    Http245 Get245(string body, Either<string, Uri> url, string contentType, params Header[] headers);
-    Http245 Get245(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers);
+    Http245 Get245(Either<string, Uri> url, params Header[] headers);
+    Http245 Get245(Either<string, Uri> url, HttpOptions options, params Header[] headers);
     HttpBody Get(Either<string, Uri> url, params Header[] headers);
     HttpBody Get(Either<string, Uri> url, HttpOptions options, params Header[] headers);
     HttpStatus GetStatus(Either<string, Uri> url, params Header[] headers);
@@ -140,8 +140,8 @@ public sealed class HttpClient : IHttpClient
     public TResponse PatchJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, params Header[] headers) => Http.PatchJson<TRequest, TResponse>(model, url, headers);
     public TResponse PatchJson<TRequest, TResponse>(TRequest model, Either<string, Uri> url, HttpOptions options, params Header[] headers) => Http.PatchJson<TRequest, TResponse>(model, url, options, headers);
 
-    public Http245 Get245(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.Get245(body, url, contentType, headers);
-    public Http245 Get245(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers) => Http.Get245(body, url, contentType, options, headers);
+    public Http245 Get245(Either<string, Uri> url, params Header[] headers) => Http.Get245(url, headers);
+    public Http245 Get245(Either<string, Uri> url, HttpOptions options, params Header[] headers) => Http.Get245(url, options, headers);
     public HttpBody Get(Either<string, Uri> url, params Header[] headers) => Http.Get(url, headers);
     public HttpBody Get(Either<string, Uri> url, HttpOptions options, params Header[] headers) => Http.Get(url, options, headers);
     public HttpStatus GetStatus(Either<string, Uri> url, params Header[] headers) => Http.GetStatus(url, headers);

--- a/src/FrameworkContainers/Network/HttpCollective/HttpClient.cs
+++ b/src/FrameworkContainers/Network/HttpCollective/HttpClient.cs
@@ -11,6 +11,8 @@ public interface IHttpClient
     HttpMaybe Maybe { get; }
     HttpResponse Response { get; }
 
+    Http245 Post245(string body, Either<string, Uri> url, string contentType, params Header[] headers);
+    Http245 Post245(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers);
     HttpBody Post(string body, Either<string, Uri> url, string contentType, params Header[] headers);
     HttpBody Post(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers);
     HttpStatus PostStatus(string body, Either<string, Uri> url, string contentType, params Header[] headers);
@@ -91,6 +93,8 @@ public sealed class HttpClient : IHttpClient
     public HttpMaybe Maybe => Http.Maybe;
     public HttpResponse Response => Http.Response;
 
+    public Http245 Post245(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.Post245(body, url, contentType, headers);
+    public Http245 Post245(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers) => Http.Post245(body, url, contentType, options, headers);
     public HttpBody Post(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.Post(body, url, contentType, headers);
     public HttpBody Post(string body, Either<string, Uri> url, string contentType, HttpOptions options, params Header[] headers) => Http.Post(body, url, contentType, options, headers);
     public HttpStatus PostStatus(string body, Either<string, Uri> url, string contentType, params Header[] headers) => Http.PostStatus(body, url, contentType, headers);

--- a/src/FrameworkContainers/Network/HttpCollective/Models/Http245.cs
+++ b/src/FrameworkContainers/Network/HttpCollective/Models/Http245.cs
@@ -1,0 +1,41 @@
+﻿namespace FrameworkContainers.Network.HttpCollective.Models
+{
+    /// <summary>A general model to cover 200, 400, and 500 http status codes in custom ways.</summary>
+    public readonly struct Http245
+    {
+        public Header[] Headers { get; }
+        public int StatusCode { get; }
+        public string Body { get; }
+
+        internal Http245(Header[] headers, int statusCode, string body)
+        {
+            Headers = headers;
+            StatusCode = statusCode;
+            Body = body;
+        }
+    }
+
+    /// <summary>Maps to a 100 range of http status codes.</summary>
+    public enum StatusRange245
+    {
+        Http200,
+        Http400,
+        Http500
+    }
+
+    public static class Http245Extensions
+    {
+        // For direct status checks, and if statements.
+        public static bool Is200(this Http245 http) => http.StatusCode >= 200 && http.StatusCode <= 299;
+        public static bool Is400(this Http245 http) => http.StatusCode >= 400 && http.StatusCode <= 499;
+        public static bool Is500(this Http245 http) => http.StatusCode >= 500 && http.StatusCode <= 599;
+
+        // For pattern matches, and switch statements.
+        public static StatusRange245 GetStatusRange(this Http245 http)
+        {
+            if (http.Is200()) return StatusRange245.Http200;
+            if (http.Is400()) return StatusRange245.Http400;
+            return StatusRange245.Http500;
+        }
+    }
+}

--- a/src/Tests.FrameworkContainers/Tests.FrameworkContainers.csproj
+++ b/src/Tests.FrameworkContainers/Tests.FrameworkContainers.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Updated nuget packages.
Added a method for custom handling of the response for 2XX / 4XX / 5XX http status codes.
This is useful when the error models are different from the resource models.